### PR TITLE
Read multiple bytes for system events

### DIFF
--- a/lib/events.ml
+++ b/lib/events.ml
@@ -120,9 +120,10 @@ open Event
 type ('a,'b) has_finished =
   | Yes of 'a
   | No  of 'b
+  | Advanced of 'b
 
 let mkReadInProgress fd = function
-  | FCons _ as f -> No (ReadInProgress(fd,f))
+  | FCons _ as f -> Advanced (ReadInProgress(fd,f))
   | FNil x -> Yes x
 
 let one_line () = Line (Bytes.make 1 '0', Buffer.create 40)

--- a/lib/sorted.ml
+++ b/lib/sorted.ml
@@ -105,3 +105,13 @@ let partition f { sorted; data } =
   in
     aux [] [] data
 
+let partition_priority f { sorted; data } =
+  let rev = if sorted then List.rev else fun x -> x in
+  let rec aux yes no = function
+    | [] -> { sorted; data = rev yes }, { sorted; data = rev no }
+    | x :: xs ->
+        if f (snd x)
+        then aux (x :: yes) no xs
+        else aux yes (x :: no) xs
+  in
+    aux [] [] data

--- a/lib/sorted.ml
+++ b/lib/sorted.ml
@@ -31,6 +31,8 @@ let lt_priority p1 p2 = cmp_priority p1 p2 < 0
 
 let le_user { user = u1; _} {user = u2; _} = u1 <= u2
 
+let min_priority p1 p2 = if cmp_priority p1 p2 < 0 then p1 else p2
+let min_user p1 p2 = if le_user p1 p2 then p1 else p2
 
 type 'a t = {
   sorted : bool;  

--- a/lib/sorted.mli
+++ b/lib/sorted.mli
@@ -50,3 +50,4 @@ val to_list : 'a t -> 'a list
 val of_list : ('a * priority) list -> 'a t
 val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit
 val partition : ('a -> bool) -> 'a t -> 'a t * 'a t
+val partition_priority : (priority -> bool) -> 'a t -> 'a t * 'a t

--- a/lib/sorted.mli
+++ b/lib/sorted.mli
@@ -26,6 +26,7 @@ val lt_priority : priority -> priority -> bool
 
 val eq_user : priority -> priority -> bool
 val le_user : priority -> priority -> bool
+val min_user : priority -> priority -> priority
 
 val default_priority : priority
 

--- a/test/fairness_prio.ml
+++ b/test/fairness_prio.ml
@@ -58,17 +58,16 @@ let read_leftover read n =
 (* pop_opt terminates *)
 let%test_unit "sel.loop" =
   let read, write = pipe () in
-  let e = On.line ~priority:1 read (fun x -> x) in
-  write "aa\nbb\ncc\n";
-  let read2, write2 = pipe () in
-  let x = On.bytes ~priority:2 read2 2 (function Error e -> Error e | Ok s -> Error (Failure (Stdlib.Format.asprintf "lower priority event triggered: '%s'" (Bytes.to_string s)))) in
+  let e = On.httpcle ~priority:1 read (fun x -> Result.map ~f:Bytes.to_string x) in
+  write "Content-Length: 3\n\n123\n";
+  let x = Sel.now ~priority:2 (Ok "bad") in
   let todo = Todo.add Todo.empty [e;x] in
   let rec loop todo =
-    let ready, todo = Sel.pop todo in
+    let ready, _todo = Sel.pop todo in
     match ready with
-    | Ok "cc" -> ()
-    | Ok s -> write2 s; loop (Todo.add todo [e])
-    | Error End_of_file -> ()
+    | Ok "bad" -> [%test_eq: string] "" "bad1"
+    | Ok "123" -> ()
+    | Ok _ -> [%test_eq: string] "" "bad2"
     | Error e -> [%test_eq: string] "" (Stdlib.Printexc.to_string e) in
   loop todo
   

--- a/test/perf.ml
+++ b/test/perf.ml
@@ -1,0 +1,74 @@
+(**************************************************************************)
+(*                                                                        *)
+(*                                 SEL                                    *)
+(*                                                                        *)
+(*                   Copyright INRIA and contributors                     *)
+(*       (see version control and README file for authors & dates)        *)
+(*                                                                        *)
+(**************************************************************************)
+(*                                                                        *)
+(*   This file is distributed under the terms of the MIT License.         *)
+(*   See LICENSE file.                                                    *)
+(*                                                                        *)
+(**************************************************************************)
+open Base
+open Sel
+
+(************************ UTILS **********************************************)
+
+(* we don't want to lock forever doing tests, esp if we know pop_opt would be
+   stuck *)
+let wait_timeout todo =
+  let ready, todo = pop_timeout ~stop_after_being_idle_for:0.1 todo in
+  [%test_eq: bool] (Option.is_none ready) true;
+  [%test_eq: bool] (Todo.is_empty todo) false;
+  ready, todo
+
+(* match a string list against a rex list, useful for errors *)
+let osmatch r s =
+  match s with
+  | None -> false
+  | Some s -> Str.string_match (Str.regexp r) s 0
+  
+let b2s = function
+  | Ok b -> Bytes.to_string b
+  | Error x -> Stdlib.Printexc.to_string x
+
+let s2s = function
+  | Ok s -> s
+  | Error x -> Stdlib.Printexc.to_string x
+
+let write_pipe write s =
+  let len = String.length s in
+  let rc = Unix.write write (Bytes.of_string s) 0 len in
+  [%test_eq: int] rc len
+
+let pipe () =
+  let read, write = Unix.pipe () in
+  read, write_pipe write
+
+let read_leftover read n =
+  let b = Bytes.create n in
+  let rc = Unix.read read b 0 n in
+  [%test_eq: int] rc n;
+  Bytes.to_string b
+  
+(*****************************************************************************)
+
+(* pop_opt terminates *)
+let%test_unit "sel.loop" =
+  let read, write = pipe () in
+  let e = On.line ~priority:1 read (fun x -> x) in
+  write "a\nb\nc\n";
+  let read, write = pipe () in
+  let x = On.bytes ~priority:2 read 2 (fun _ -> Error (Failure "lower priority event triggered")) in
+  let todo = Todo.add Todo.empty [e;x] in
+  let rec loop todo =
+    let ready, todo = Sel.pop todo in
+    match ready with
+    | Ok "c" -> ()
+    | Ok s -> write s; loop (Todo.add todo [e])
+    | Error End_of_file -> ()
+    | Error e -> [%test_eq: string] "" (Stdlib.Printexc.to_string e) in
+  loop todo
+  


### PR DESCRIPTION
When checking for system events, the current version would read `1` byte per iteration, meaning that when other tasks are ready, reading `n` bytes becomes interleaved with `n` other tasks. These tasks may be slow, resulting in unnecessary slowdowns of system events (such as UI events in vscoq).

This change allows reading another byte from its file descriptor when:
1. The system event has lower priority than the lowest priority ready event
2. The event just read an available byte from the file descriptor.
